### PR TITLE
Add an ability to reply a user with a custom component

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 import createFlowBot from '../src/init.jsx';
 import config from '../src/examples/config.js';
+import getWidgets from '../src/examples/widgets/index.js';
 
 const initialHtml = '<div id="container"></div>';
 
@@ -58,4 +59,26 @@ test('conversation with the bot', async () => {
     expect(screen.getByRole('button', { name: /Show engine type/i })).toBeInTheDocument();
     expect(document.getElementById('container')).toMatchSnapshot();
   });
+});
+
+test('widgets', async () => {
+  const user = userEvent.setup();
+  const bot = await createFlowBot(config, { getWidgets });
+  render(bot, { container: document.getElementById('container') });
+  const firstWidgetText = 'Anti-lock braking system (ABS)';
+  const firstWidgetLinkText = 'See more information about ABS on Wikipedia';
+  const secondWidgetText = 'Electronic stability control (ESC)';
+  const secondWidgetLinkText = 'See more information about ESP on Wikipedia';
+
+  const botToggler = screen.getByRole('button');
+  await user.click(botToggler);
+
+  const questionButton = screen.getByRole('button', { name: /Show breaks/i });
+  await user.click(questionButton);
+
+  expect(await screen.findAllByTestId('widget')).toHaveLength(2);
+  expect(screen.getByText(firstWidgetText)).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: firstWidgetLinkText })).toBeInTheDocument();
+  expect(screen.getByText(secondWidgetText)).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: secondWidgetLinkText })).toBeInTheDocument();
 });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 import createFlowBot from '../src/init.jsx';
 import config from '../src/examples/config.js';
-import getWidgets from '../src/examples/widgets/index.js';
+import getWidget from '../src/examples/widgets/index.js';
 
 const initialHtml = '<div id="container"></div>';
 
@@ -63,7 +63,7 @@ test('conversation with the bot', async () => {
 
 test('widgets', async () => {
   const user = userEvent.setup();
-  const bot = await createFlowBot(config, { getWidgets });
+  const bot = await createFlowBot(config, { getWidget });
   render(bot, { container: document.getElementById('container') });
   const firstWidgetText = 'Anti-lock braking system (ABS)';
   const firstWidgetLinkText = 'See more information about ABS on Wikipedia';

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -7,10 +7,10 @@ import BotBox from './BotBox';
 
 const App = ({ botMachine, options }) => {
   const botService = useInterpret(botMachine);
-  const { getWidgets } = options;
+  const { getWidget } = options;
 
   return (
-    <GlobalStateContext.Provider value={{ botService, getWidgets }}>
+    <GlobalStateContext.Provider value={{ botService, getWidget }}>
       <BotBox />
     </GlobalStateContext.Provider>
   );
@@ -19,7 +19,7 @@ const App = ({ botMachine, options }) => {
 App.propTypes = {
   botMachine: PropTypes.object, // eslint-disable-line
   options: PropTypes.shape({
-    getWidgets: PropTypes.func,
+    getWidget: PropTypes.func,
   }),
 };
 

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -5,11 +5,12 @@ import PropTypes from 'prop-types';
 import GlobalStateContext from '../context';
 import BotBox from './BotBox';
 
-const App = ({ botMachine }) => {
+const App = ({ botMachine, options }) => {
   const botService = useInterpret(botMachine);
+  const { getWidgets } = options;
 
   return (
-    <GlobalStateContext.Provider value={{ botService }}>
+    <GlobalStateContext.Provider value={{ botService, getWidgets }}>
       <BotBox />
     </GlobalStateContext.Provider>
   );
@@ -17,6 +18,14 @@ const App = ({ botMachine }) => {
 
 App.propTypes = {
   botMachine: PropTypes.object, // eslint-disable-line
+  options: PropTypes.shape({
+    getWidgets: PropTypes.func,
+  }),
+};
+
+App.defaultProps = {
+  botMachine: {},
+  options: {},
 };
 
 export default App;

--- a/src/components/BotMessage.jsx
+++ b/src/components/BotMessage.jsx
@@ -2,21 +2,33 @@ import React from 'react';
 import { Row, Col } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 
-const BotMessage = ({ messageData }) => (
-  <Row>
-    <Col md={8}>{messageData.content}</Col>
-  </Row>
+import Widget from './Widget.jsx';
+
+const BotMessage = ({ messageData: { content, widgetData } }) => (
+  <>
+    <Row>
+      <Col md={8}>
+        {content}
+      </Col>
+    </Row>
+    {widgetData.map(({ name, id }) => <Widget key={id} name={name} />)}
+  </>
 );
 
 BotMessage.propTypes = {
   messageData: PropTypes.shape({
     content: PropTypes.string,
+    widgetData: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.string,
+      name: PropTypes.string,
+    })),
   }),
 };
 
 BotMessage.defaultProps = {
   messageData: {
     content: '',
+    widgetData: [],
   },
 };
 

--- a/src/components/Widget.jsx
+++ b/src/components/Widget.jsx
@@ -1,0 +1,28 @@
+import React, { useContext } from 'react';
+import { Row, Col, Card } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+
+import GlobalStateContext from '../context';
+
+const Widget = ({ name }) => {
+  const { getWidgets } = useContext(GlobalStateContext);
+  const Component = getWidgets(name);
+
+  return (
+    <Row className="mb-2" data-testid="widget">
+      <Col md={8}>
+        <Card style={{ width: '300px' }}>
+          <Card.Body className="overflow-hidden">
+            <Component />
+          </Card.Body>
+        </Card>
+      </Col>
+    </Row>
+  );
+};
+
+Widget.propTypes = {
+  name: PropTypes.string.isRequired,
+};
+
+export default Widget;

--- a/src/components/Widget.jsx
+++ b/src/components/Widget.jsx
@@ -5,8 +5,8 @@ import PropTypes from 'prop-types';
 import GlobalStateContext from '../context';
 
 const Widget = ({ name }) => {
-  const { getWidgets } = useContext(GlobalStateContext);
-  const Component = getWidgets(name);
+  const { getWidget } = useContext(GlobalStateContext);
+  const Component = getWidget(name);
 
   return (
     <Row className="mb-2" data-testid="widget">

--- a/src/examples/config.js
+++ b/src/examples/config.js
@@ -44,6 +44,10 @@ const botConfiguration = {
         'wheels',
         'overallConstruction',
       ],
+      widgets: [
+        'ABS',
+        'ESP',
+      ],
     },
   ],
   questions: [

--- a/src/examples/widgets/ABS.jsx
+++ b/src/examples/widgets/ABS.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default () => (
+  <div>
+    <div>
+      Anti-lock braking system (ABS)
+    </div>
+    <a href="https://en.wikipedia.org/wiki/Anti-lock_braking_system" className="link-primary">
+      See more information about ABS on Wikipedia
+    </a>
+  </div>
+);

--- a/src/examples/widgets/ESP.jsx
+++ b/src/examples/widgets/ESP.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default () => (
+  <div>
+    <div>
+      Electronic stability control (ESC)
+    </div>
+    <a href="https://en.wikipedia.org/wiki/Electronic_stability_control" className="link-primary">
+      See more information about ESP on Wikipedia
+    </a>
+  </div>
+);

--- a/src/examples/widgets/index.js
+++ b/src/examples/widgets/index.js
@@ -1,0 +1,9 @@
+import ABS from './ABS.jsx';
+import ESP from './ESP.jsx';
+
+const widgets = {
+  ABS,
+  ESP,
+};
+
+export default (name) => widgets[name];

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -5,10 +5,10 @@ import ReactDOM from 'react-dom';
 import './styles/style.scss';
 import createFlowBot from './init';
 import configurationExample from './examples/config';
-import getWidgets from './examples/widgets/index.js';
+import getWidget from './examples/widgets/index.js';
 
 const run = () => {
-  const flowbot = createFlowBot(configurationExample, { getWidgets });
+  const flowbot = createFlowBot(configurationExample, { getWidget });
   const root = document.getElementById('root');
   ReactDOM.render(flowbot, root);
 };

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,9 +4,11 @@ import ReactDOM from 'react-dom';
 
 import './styles/style.scss';
 import createFlowBot from './init';
+import configurationExample from './examples/config';
+import getWidgets from './examples/widgets/index.js';
 
 const run = () => {
-  const flowbot = createFlowBot();
+  const flowbot = createFlowBot(configurationExample, { getWidgets });
   const root = document.getElementById('root');
   ReactDOM.render(flowbot, root);
 };

--- a/src/init.jsx
+++ b/src/init.jsx
@@ -4,7 +4,7 @@ import createBotMachine from './machine/flowbotMachine';
 import App from './components/App';
 
 const defaultOptions = {
-  getWidgets: () => null,
+  getWidget: () => null,
 };
 
 export default (configuration, userDefinedOptions = {}) => {

--- a/src/init.jsx
+++ b/src/init.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 
-import configurationExample from './examples/config';
 import createBotMachine from './machine/flowbotMachine';
 import App from './components/App';
 
-export default (configuration = configurationExample) => {
+const defaultOptions = {
+  getWidgets: () => null,
+};
+
+export default (configuration, userDefinedOptions = {}) => {
+  const options = { ...defaultOptions, ...userDefinedOptions };
   const botMachine = createBotMachine(configuration);
 
-  return <App botMachine={botMachine} />;
+  return <App botMachine={botMachine} options={options} />;
 };

--- a/src/machine/answeringMachine.js
+++ b/src/machine/answeringMachine.js
@@ -19,9 +19,12 @@ export default createMachine({
               ));
               return { ...questionData, id: generateId() };
             });
+            const widgetNames = answerData.widgets || [];
+            const widgetData = widgetNames.map((name) => ({ name, id: generateId() }));
             const payload = {
               answerData,
               nextQuestions,
+              widgetData,
             };
 
             return { type: 'REPLY', payload };

--- a/src/machine/flowbotMachine.js
+++ b/src/machine/flowbotMachine.js
@@ -3,7 +3,12 @@ import answeringMachine from './answeringMachine';
 import generateId from '../utils/idGenerator';
 
 const getInitMessages = (config) => (
-  config.initMessages.map((message) => ({ type: 'bot', content: message, id: generateId() }))
+  config.initMessages.map((message) => ({
+    type: 'bot',
+    content: message,
+    id: generateId(),
+    widgetData: [],
+  }))
 );
 
 const getInitQuestions = (config) => (
@@ -64,7 +69,12 @@ const createBotMachine = (configuration) => {
             actions: assign({
               messages: (context, event) => [
                 ...context.messages,
-                { type: 'bot', content: event.payload.answerData.content, id: generateId() },
+                {
+                  type: 'bot',
+                  content: event.payload.answerData.content,
+                  id: generateId(),
+                  widgetData: event.payload.widgetData,
+                },
               ],
               currentQuestions: (context, event) => event.payload.nextQuestions,
             }),


### PR DESCRIPTION
Чтобы иметь возможность ответить с помощью кастомного компонента нужно:
1. Элементу ответа в конфигурации добавить поле widgets, в нем указать имена всех виджетов, которые нужно выдать пользователю в качестве ответа:
```
answers: [ 
   {
      name: 'brakesCharacteristics',
      ...
      widgets: [
        'ABS',
        ...
      ],
    },
],
```

2. Создать реакт-компонент:
` const CustomWidget = () => <div>Hello from the custom widget</div>;`

3. Создать функцию с именем `getWidget`, которая принимает имя виджета из конфигурации (в нашем случае это `'ABS'`), и возвращает компонент виджета:
`getWidget = (name) => { ... return CustomWidget; }`

4. Передать функцию `getWidget` в функцию создания бота в качестве опции:
```
import createFlowBot from './init';
import getWidget from './examples/widgets/index.js';

const run = () => {
  const flowbot = createFlowBot(configurationExample, { getWidget });
  const root = document.getElementById('root');
  ReactDOM.render(flowbot, root);
};
```
Теперь, когда на вопрос пользователя подразумевается ответ с виджетами, то после текстового описания ответа будут выведены кастомные компоненты в том порядке, в котором они указаны в конфигурации.
